### PR TITLE
EFIC-203: better and accurate matching for user*_project_wrapper@{.gds|.gds.gz} 

### DIFF
--- a/mpw_precheck.py
+++ b/mpw_precheck.py
@@ -90,12 +90,6 @@ def main(*args, **kwargs):
     pdks_info_path = precheck_config['log_path'].parent / 'pdks.info'
     log_tools_info(precheck_config['pdk_root'], tools_info_path, pdks_info_path)
 
-    gds_file_path = precheck_config['input_directory'] / f"gds/{project_config['user_module']}.gds"
-    compressed_gds_file_path = precheck_config['input_directory'] / f"gds/{project_config['user_module']}.gds.gz"
-    if gds_file_path.exists() and compressed_gds_file_path.exists():
-        logging.fatal("{{GDS VIOLATION}} Both a compressed and an uncompressed version the gds exist, ensure only one design file exists.")
-        sys.exit(255)
-
     run_precheck_sequence(precheck_config=precheck_config, project_config=project_config)
 
 


### PR DESCRIPTION
EFIC-203: better and accurate matching for user*_project_wrapper@{.gds|.gds.gz} when identifying the project type + removes redundant compressed vs uncompressed gds check. This commit fixes the issue of identifying a digital project as an analog one