### PR TITLE
Exclude min area for areaid.ce

### DIFF
--- a/checks/tech-files/sky130A_mr.drc
+++ b/checks/tech-files/sky130A_mr.drc
@@ -387,7 +387,7 @@ li_edges_with_less_enclosure = li.enclosing(licon_peri, 0.08, projection).second
 error_corners = li_edges_with_less_enclosure.width(angle_limit(100.0), 1.dbu)
 li_interact = licon_peri.interacting(error_corners.polygons(1.dbu))
 li_interact.output("li.5", "li.5 : min. li enclosure of licon of 2 adjacent edges : 0.08um")
-li.with_area(nil, 0.0561).output("li.6", "li.6 : min. li area : 0.0561um²")
+linotace.with_area(nil, 0.0561).output("li.6", "li.6 : min. li area : 0.0561um²")
 log("END: 67/20 (li)")
 
 #   ct


### PR DESCRIPTION
The rules incorrectly flagged the following LI as a min area violation in the bitcell, but it should not be.
![li_area_error](https://user-images.githubusercontent.com/12450095/172462017-b86ae9f3-3b1a-4837-a999-3a4edf283b98.png)

