### PR TITLE
EF-3614-a | fix | fix wrong varaible usage preventing using the mpw precheck as a module

### DIFF
--- a/mpw_precheck.py
+++ b/mpw_precheck.py
@@ -98,7 +98,7 @@ def main(*args, **kwargs):
 
     log_info(precheck_config, project_config)
     # note: update to filter sequence based on supported pdks
-    precheck_config['sequence'] = [check for check in sequence if precheck_config['pdk_path'].stem in get_check_manager(check, precheck_config, project_config).__supported_pdks__]
+    precheck_config['sequence'] = [check for check in precheck_config['sequence'] if precheck_config['pdk_path'].stem in get_check_manager(check, precheck_config, project_config).__supported_pdks__]
     run_precheck_sequence(precheck_config=precheck_config, project_config=project_config)
 
 


### PR DESCRIPTION
- Correctly use 'precheck_config['sequence']' to access check sequence instead of local variable 'sequence'