### PR TITLE
Gf180 klay drc option processing fixes & elim. redundant rules. Improvements to klayout process error checking.

### DIFF
--- a/checks/drc_checks/klayout/klayout_gds_drc_check.py
+++ b/checks/drc_checks/klayout/klayout_gds_drc_check.py
@@ -1,12 +1,14 @@
 import argparse
 import logging
 import subprocess
+import os
 from pathlib import Path
 
-
 def klayout_gds_drc_check(check_name, drc_script_path, gds_input_file_path, output_directory, klayout_cmd_extra_args=[]):
+    logging.info("in CUSTOM klayout_gds_drc_check")
     report_file_path = output_directory / 'outputs/reports' / f'{check_name}_check.xml'
     logs_directory = output_directory / 'logs'
+    total_file_path = logs_directory / f'{check_name}_check.total'
     run_drc_check_cmd = ['klayout', '-b', '-r', drc_script_path,
                          '-rd', f"input={gds_input_file_path}",
                          '-rd', f"topcell={gds_input_file_path.stem}",
@@ -14,21 +16,39 @@ def klayout_gds_drc_check(check_name, drc_script_path, gds_input_file_path, outp
     run_drc_check_cmd.extend(klayout_cmd_extra_args)
 
     log_file_path = logs_directory / f'{check_name}_check.log'
+    cmd = ' '.join(str(x) for x in run_drc_check_cmd) + ' >& ' + str(log_file_path)
     with open(log_file_path, 'w') as klayout_drc_log:
-        subprocess.run(run_drc_check_cmd, stderr=klayout_drc_log, stdout=klayout_drc_log)
-
-    with open(report_file_path) as klayout_xml_report:
-        drc_content = klayout_xml_report.read()
-        drc_count = drc_content.count('<item>')
-        total_file_path = logs_directory / f'{check_name}_check.total'
-        with open(total_file_path, 'w') as drc_total:
-            drc_total.write(f"{drc_count}")
-        if drc_count == 0:
-            logging.info("No DRC Violations found")
-            return True
-        else:
-            logging.error(f"Total # of DRC violations is {drc_count} Please check {report_file_path} For more details")
+        logging.info(f"run: {cmd}") # helpful reference, print long-cmd once & messages below remain concise
+        p = subprocess.run(run_drc_check_cmd, stderr=klayout_drc_log, stdout=klayout_drc_log)
+        # Check exit-status of all subprocesses
+        stat = p.returncode
+        if stat != 0:
+            logging.error(f"ERROR {check_name} FAILED, stat={stat}, see {log_file_path}")
             return False
+
+    try:
+        with open(report_file_path) as klayout_xml_report:
+            size = os.fstat(klayout_xml_report.fileno()).st_size
+            if size == 0:
+                logging.error(f"ERROR {check_name} WROTE DEGENERATE {report_file_path.name}: empty")
+                return False
+            drc_content = klayout_xml_report.read()
+            drc_count = drc_content.count('<item>')
+            with open(total_file_path, 'w') as drc_total:
+                drc_total.write(f"{drc_count}")
+            if drc_count == 0:
+                logging.info("No DRC Violations found")
+                return True
+            else:
+                logging.error(f"Total # of DRC violations is {drc_count} Please check {report_file_path} For more details")
+                return False
+    # Catch reports not found (vs crude abort with exception).
+    except FileNotFoundError as e:
+        logging.error(f"ERROR {check_name} FAILED TO GENERATE {report_file_path.name}: {e}")
+    except (IOError, OSError) as e:
+        logging.error(f"ERROR {check_name} FAILED TO GENERATE {total_file_path.name}: {e}")
+
+    return False
 
 
 if __name__ == "__main__":

--- a/checks/tech-files/gf180mcuC_mr.drc
+++ b/checks/tech-files/gf180mcuC_mr.drc
@@ -37,13 +37,13 @@ def getMemSize
     end
   end
   return mSize
-end
+end #def
 
 logger = Logger.new(STDOUT)
 logger.formatter = proc do |severity, datetime, progname, msg|
   # "#{datetime}: Memory Usage (" + getMemSize() + ") : #{msg}\n"
   "#{datetime}: Memory Usage (" + `pmap #{Process.pid} | tail -1`[10,40].strip + ") : #{msg}\n"
-end
+end #do
 
 #================================================
 #----------------- FILE SETUP -------------------
@@ -191,7 +191,7 @@ neo_ee_mk      = polygons(88 , 17)
 sramcore       = polygons(108, 5 )
 lvs_rf         = polygons(100, 5 )
 lvs_drain      = polygons(100, 7 )
-ind_mk         = polygons(151, 5 )
+## dup: ind_mk         = polygons(151, 5 )
 hvpolyrs       = polygons(123, 5 )
 lvs_io         = polygons(119, 5 )
 probe_mk       = polygons(13 , 17)
@@ -378,8 +378,8 @@ lvs_rf_count                   = lvs_rf.count()
 poly_count                     = poly_count + lvs_rf_count
 lvs_drain_count                = lvs_drain.count()
 poly_count                     = poly_count + lvs_drain_count
-ind_mk_count                   = ind_mk.count()
-poly_count                     = poly_count + ind_mk_count
+## dup: ind_mk_count                   = ind_mk.count()
+## dup: poly_count                     = poly_count + ind_mk_count
 hvpolyrs_count                 = hvpolyrs.count()
 poly_count                     = poly_count + hvpolyrs_count
 lvs_io_count                   = lvs_io.count()
@@ -452,30 +452,31 @@ natcompsd	 = (nat       & comp.interacting(poly2)) - tgate
 #================================================
 logger.info("Evaluate switches.")
 
+# Coerce optional flag-args to booleans, case-insensitive, survives absence (nil-class).
+FEOL               =     $feol.to_s.downcase=="true"
+BEOL               =     $beol.to_s.downcase=="true"
+BEOL_EXTEND        = BEOL
+CONNECTIVITY_RULES = $conn_drc.to_s.downcase=="true"
+OFFGRID            =  $offgrid.to_s.downcase=="true"
+
 # FEOL
-if $feol == "true"
-  FEOL = $feol
+if ! FEOL
   logger.info("FEOL is disabled.")
 else
-  FEOL = "false"
   logger.info("FEOL is enabled.")
 end # FEOL
 
 # BEOL
-if $beol == "true"
-  BEOL = $beol
+if ! BEOL
   logger.info("BEOL is disabled.")
 else
-  BEOL = "false"
   logger.info("BEOL is enabled.")
 end # BEOL
 
 # connectivity rules
-if $conn_drc == "true"
-  CONNECTIVITY_RULES = $conn_drc
+if CONNECTIVITY_RULES
   logger.info("connectivity rules are enabled.")
 else
-  CONNECTIVITY_RULES = false
   logger.info("connectivity rules are disabled.")
 end # connectivity rules
 
@@ -528,17 +529,11 @@ if $mim_option
   MIM_OPTION = $mim_option
 else
   MIM_OPTION = "Nan"
-end
+end # mim_option
 
 logger.info("MIM Option selected %s" % [MIM_OPTION])
 
 # OFFGRID
-if $offgrid == "true"
-  OFFGRID = true
-else
-  OFFGRID = false
-end # OFFGRID
-
 logger.info("Offgrid enabled  %s" % [OFFGRID])
 
 #================================================
@@ -577,7 +572,7 @@ end #METAL_LEVEL
 #------------- LAYERS CONNECTIONS ---------------
 #================================================
 
-if CONNECTIVITY_RULES
+if CONNECTIVITY_RULES && (FEOL || BEOL)    # required for FEOL or BEOL; But Skip for OFFGRID.
 
   logger.info("Construct connectivity for the design.")
 
@@ -625,10 +620,10 @@ def conn_space(layer,conn_val,not_conn_val, mode)
       # unconnected
       unconnected_errors.data.insert(ep)
     end
-  end
+  end #do
   unconnected_output = unconnected_errors.polygons.or(singularity_errors.polygons(0.001))
   return connected_output, unconnected_output
-end
+end #def
 
 def conn_separation(layer1, layer2, conn_val,not_conn_val, mode)
   if conn_val > not_conn_val
@@ -647,10 +642,10 @@ def conn_separation(layer1, layer2, conn_val,not_conn_val, mode)
       # unconnected
       unconnected_errors.data.insert(ep)
     end
-  end
+  end #do
   unconnected_output = unconnected_errors.polygons(0.001)
   return connected_output, unconnected_output
-end
+end #def
 
 # === IMPLICIT EXTRACTION ===
 if CONNECTIVITY_RULES
@@ -3188,6 +3183,8 @@ end #METAL_TOP
 
 end #BEOL
 
+if BEOL_EXTEND   # were unconditional rules, now specific to BEOL: Not Repeated by each discrete job (by FEOL, OFFGRID)
+
 #================================================
 #---------------------MCELL----------------------
 #================================================
@@ -3571,13 +3568,13 @@ mim11_large_metal2.data.each do |p|
   mim11_metal2_polygon_layer = polygon_layer
   mim11_metal2_polygon_layer.data.insert(p)
   fuse_in_polygon = fusetop.and(mim11_metal2_polygon_layer)
-  if(fuse_in_polygon.area > 10000)
+  if (fuse_in_polygon.area > 10000)
     mim11_bad_metal2_polygon = mim11_metal2_polygon_layer.interacting(fuse_in_polygon)
     mim11_bad_metal2_polygon.data.each do |b|
       b.num_points > 0 && mim11_large_metal2_violation.data.insert(b)
-    end
+    end #do
   end
-end
+end #do
 # Rule MIM.11: Bottom plate of multiple MIM caps can be shared (for common nodes) as long as total MIM area with that single common plate does not exceed MIM.8b rule. is -µm
 logger.info("Executing rule MIM.11")
 mim11_l1  = mim11_large_metal2_violation
@@ -3680,13 +3677,13 @@ mimtm11_large_topmin1_metal.data.each do |p|
   mimtm11_topmin1_metal_polygon_layer = polygon_layer
   mimtm11_topmin1_metal_polygon_layer.data.insert(p)
   fuse_in_polygon = fusetop.and(mimtm11_topmin1_metal_polygon_layer)
-  if(fuse_in_polygon.area > 10000)
+  if (fuse_in_polygon.area > 10000)
     mimtm11_bad_topmin1_metal_polygon = mimtm11_topmin1_metal_polygon_layer.interacting(fuse_in_polygon)
     mimtm11_bad_topmin1_metal_polygon.data.each do |b|
       b.num_points > 0 && mimtm11_large_topmin1_metal_violation.data.insert(b)
-    end
+    end #do
   end
-end
+end #do
 # Rule MIMTM.11: Bottom plate of multiple MIM caps can be shared (for common nodes) as long as total MIM area with that single common plate does not exceed MIMTM.8b rule. is -µm
 logger.info("Executing rule MIMTM.11")
 mimtm11_l1  = mimtm11_large_topmin1_metal_violation
@@ -5034,6 +5031,8 @@ sm11_l1  = metal1.and(sramcore).width(0.22.um, euclidian).polygons(0.001).not_in
 sm11_l1.output("S.M1.1_LV", "S.M1.1_LV : min. metal1 width : 0.22µm")
 sm11_l1.forget
 
+end # BEOL_EXTEND   # previously unconditional top-level block, now rolled into BEOL
+
 #================================================
 #-----------------GEOMETRY RULES-----------------
 #================================================
@@ -5353,9 +5352,9 @@ logger.info("Executing rule lvs_drain_OFFGRID")
 lvs_drain.ongrid(0.005).output("lvs_drain_OFFGRID", "OFFGRID : OFFGRID vertex on lvs_drain")
 lvs_drain.with_angle(0 .. 45).output("lvs_drain_angle", "ACUTE : non 45 degree angle lvs_drain")
 
-logger.info("Executing rule ind_mk_OFFGRID")
-ind_mk.ongrid(0.005).output("ind_mk_OFFGRID", "OFFGRID : OFFGRID vertex on ind_mk")
-ind_mk.with_angle(0 .. 45).output("ind_mk_angle", "ACUTE : non 45 degree angle ind_mk")
+## dup: logger.info("Executing rule ind_mk_OFFGRID")
+## dup: ind_mk.ongrid(0.005).output("ind_mk_OFFGRID", "OFFGRID : OFFGRID vertex on ind_mk")
+## dup: ind_mk.with_angle(0 .. 45).output("ind_mk_angle", "ACUTE : non 45 degree angle ind_mk")
 
 logger.info("Executing rule hvpolyrs_OFFGRID")
 hvpolyrs.ongrid(0.005).output("hvpolyrs_OFFGRID", "OFFGRID : OFFGRID vertex on hvpolyrs")
@@ -5469,7 +5468,7 @@ end #OFFGRID-ANGLES
 
 if   File.readable?("/proc/self/status")
   puts File.foreach("/proc/self/status").grep(/^(VmPeak|VmHWM)/)
-end
+end #VmPeak
 
 exec_end_time = Time.now
 run_time = exec_end_time - exec_start_time


### PR DESCRIPTION
Improve error-checking of klayout runs, esp. when running out of mem/swap, and/or failing to write .xml report.
In GF180 rules: Eliminate redundant/wasted rules across separate feol,beol,offgrid runs.
Still GF180 rules will require large peak VSIZE, i.e. 15GB or 32GB RAM plus 60GB swap.
Recommend on-platform batch queues with 32GB RAM plus 150GB swap.