### PR TITLE
Changes to analog design consistency checks.

### DIFF
--- a/checks/consistency_check/consistency_check.py
+++ b/checks/consistency_check/consistency_check.py
@@ -79,7 +79,8 @@ def main(*args, **kwargs):
 
     # Parse netlists (spice/verilog)
     try:
-        top_netlist_parser = get_netlist_parser(project_config['top_netlist'], project_config['top_module'], project_config['netlist_type'], include_files=include_files, preprocess_define=PREPROCESS_DEFINES)
+        top_netlist_parser = get_netlist_parser(project_config['top_netlist'], project_config['top_module'], 'verilog',  include_files=include_files, preprocess_define=PREPROCESS_DEFINES)
+        #top_netlist_parser = get_netlist_parser(project_config['top_netlist'], project_config['top_module'], project_config['netlist_type'], include_files=include_files, preprocess_define=PREPROCESS_DEFINES)
         user_netlist_parser = get_netlist_parser(project_config['user_netlist'], project_config['user_module'], project_config['netlist_type'], include_files=include_files, preprocess_define=PREPROCESS_DEFINES)
         golden_wrapper_parser = VerilogParser(golden_wrapper_netlist, project_config['user_module'], include_files=include_files, preprocess_define=PREPROCESS_DEFINES)
     except netlist_parser.DataError as e:

--- a/checks/utils/utils.py
+++ b/checks/utils/utils.py
@@ -68,7 +68,8 @@ def get_project_config(project_path, caravel_root):
         project_config['top_module'] = 'caravan'
         project_config['user_module'] = 'user_analog_project_wrapper'
         project_config['golden_wrapper'] = 'user_analog_project_wrapper_empty'
-        project_config['top_netlist'] = caravel_root / "spi/lvs/caravan.spice"
+        #project_config['top_netlist'] = caravel_root / "spi/lvs/caravan.spice"
+        project_config['top_netlist'] = caravel_root / "verilog/gl/caravan.v"
         project_config['user_netlist'] = project_path / "netgen/user_analog_project_wrapper.spice"
     elif digital_gds_path.exists() and not analog_gds_path.exists():
         project_config['type'] = 'digital'


### PR DESCRIPTION
Use verilog/gl/caravan.v as golden netlist.
Always treat top netlist as verilog.

Fixes #163