### PR TITLE
use hdl containers

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: .
+          context: dependencies/
           push: ${{ github.ref_name == 'main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pr:
+  pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,45 @@
+# from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - main
+  pr:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.ref_name == 'main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -13,66 +13,53 @@
 # limitations under the License.
 # SPDX-License-Identifier: Apache-2.0
 
-# Note: to get cores or use gdb start like:   docker run --ulimit core=-1 --cap-add SYS_PTRACE ...
+FROM gcr.io/hdl-containers/debian/bullseye/build/base
 
-# syntax = docker/dockerfile:1.0-experimental
-FROM centos:centos7 as build
+# klayout deps
+COPY --from=gcr.io/hdl-containers/debian/bullseye/pkg/klayout /klayout /
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    libpulse-mainloop-glib0 libpython3.9 libqt5core5a libqt5designer5 libqt5gui5 libqt5multimedia5 libqt5multimediawidgets5 libqt5printsupport5 libqt5sql5 libqt5svg5 libqt5widgets5 libqt5xml5 libqt5xmlpatterns5 libruby \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \    
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=gcr.io/hdl-containers/debian/bullseye/pkg/klayout /klayout/ /  
+RUN klayout -v
 
-# ENV VARIABLES
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-ENV LC_CTYPE en_US.UTF-8
+# magic deps
+COPY --from=gcr.io/hdl-containers/debian/bullseye/pkg/magic /magic/ /
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    libcairo2 libglu1-mesa libncurses6 libx11-6 tcl tk \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=gcr.io/hdl-containers/debian/bullseye/pkg/magic /magic/ / 
+RUN magic --version
 
-# Common development tools and libraries (kitchen sink approach)
-RUN yum -y install deltarpm.x86_64 centos-release-scl && \
-    yum -y install devtoolset-8 devtoolset-8-libatomic-devel && \
-    yum -y install https://repo.ius.io/ius-release-el7.rpm && \
-    yum -y install -y python36u python36u-devel python36u-libs python36u-pip python36u-tkinter && \
-    yum clean all && \
-    rm -rf /var/cache/yum
+# iverilog deps
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    perl \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=gcr.io/hdl-containers/debian/bullseye/pkg/iverilog /iverilog/ /
+RUN iverilog -V
 
-# Set python 3.6 as default python3
-RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 60
-RUN pip3.6 install --no-cache-dir --upgrade pip && \
-    pip3.6 install --no-cache-dir awscli boto3 colorama coloredlogs klayout numpy PySpice pyverilog pyyaml requests strsimpy
+# precheck deps
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    python3 python3-pip git make \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install awscli boto3 colorama coloredlogs klayout numpy PySpice pyverilog pyyaml requests strsimpy
 
-# General Dependencies
-RUN yum install -y tcllib tcl tk libjpeg libgomp libXext libSM libXft libffi cairo gettext Xvfb gcc-c++ gdb.x86_64 file.x86_64 time.x86_64 && \
-    yum install -y csh libglu libX11-devel ncurses-devel tcl-devel tk-devel wget && \
-    yum install -y git patch ruby && \
-    yum install -y iverilog && \
-    yum install -y https://www.klayout.org/downloads/CentOS_7/klayout-0.27.12-0.x86_64.rpm && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
-# uninstall current version of git and install latest version available in rhel/7
-RUN yum -y remove git && yum -y remove git-* && \
-    yum -y install https://repo.ius.io/7/x86_64/packages/g/git236-2.36.1-2.el7.ius.x86_64.rpm && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
-# Clone Magic
-ENV MAGIC_ROOT=./magic
-RUN git clone --depth=1 --branch 8.3.346 https://github.com/RTimothyEdwards/magic.git ${MAGIC_ROOT}
-WORKDIR $MAGIC_ROOT
-# Build Magic
-# '-O0' : disable optimization so vars visible in gdb (not optimized away). Already the default of gcc.
-# -g    : keep debugging info, incl. symbols.
-# --disable-locking : recommended by tim due to cell-depth of sky130A PDK cells.
-# scl enable devtoolset-8 --  : use the devtoolset-8 gcc-8.x (not the native gcc-4.x).
-# Note: to use gdb start like:   docker run --ulimit core=-1 --cap-add SYS_PTRACE ...
-RUN scl enable devtoolset-8 -- ./configure --prefix=/build CFLAGS='-g -O0 -m64 -fPIC' && \
-    scl enable devtoolset-8 -- make -j4 && \
-    scl enable devtoolset-8 -- make install
-
-# ENV VARIABLES
-ENV BUILD_PATH=/build/
-ENV LD_LIBRARY_PATH=$BUILD_PATH/lib:$BUILD_PATH/lib/Linux-x86_64:$LD_LIBRARY_PATH
-ENV MANPATH=$BUILD_PATH/share/man:$MANPATH
 ENV PRECHECKER_ROOT=/opt/
 ENV PATH=$PRECHECKER_ROOT:$PRECHECKER_ROOT/scripts:$BUILD_PATH/bin:$BUILD_PATH/bin/Linux-x86_64:$BUILD_PATH/pdn/scripts:$PATH
 WORKDIR $PRECHECKER_ROOT
 
-# GOLDEN CARAVEL
+# GOLDEN CARAVEL SKY130
 ENV GOLDEN_CARAVEL=/opt/caravel
 RUN git clone --branch mpw-8c --depth=1 https://github.com/efabless/caravel-lite.git ${GOLDEN_CARAVEL} && make -C ${GOLDEN_CARAVEL} uncompress
+
+# GOLDEN CARAVEL GF180MCU
+ENV GOLDEN_CARAVEL_GF180MCU=/opt/caravel-gf180mcu
+RUN git clone --branch gfmpw-0d --depth=1 https://github.com/efabless/caravel-gf180mcu.git ${GOLDEN_CARAVEL_GF180MCU} && make -C ${GOLDEN_CARAVEL_GF180MCU} uncompress

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -47,7 +47,7 @@ RUN iverilog -V
 # precheck deps
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    python3 python3-pip git make \
+    python3 python3-pip git make procps \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip install awscli boto3 colorama coloredlogs klayout numpy PySpice pyverilog pyyaml requests strsimpy


### PR DESCRIPTION
# Changes

- use  containers images from https://hdl.github.io/containers/
- copy klayout (`0.28`), magic (`8.3.348`) and verilog (`12.0`) binaries from `pkg` images variant
- install dependencies
- add ci workflows to publish images to https://docs.github.com/en/packages
- add gf180mcu caravel
- should workaround https://github.com/KLayout/klayout/issues/1189 because it includes https://github.com/KLayout/klayout/pull/1193
- should fix #172 and allow us to run precheck in GitHub actions again.

# Package

https://github.com/proppy/mpw_precheck/pkgs/container/mpw_precheck

# Test

You can test it by running the following command before running `make run-precheck` in `caravel_user_project`:
```
docker pull ghcr.io/proppy/mpw_precheck:main
docker tag ghcr.io/proppy/mpw_precheck:main efabless/mpw_precheck:latest
```

When testing it on the default `user_proj_example` I get:
```
{{FAILURE}} 2 Check(s) Failed: ['GPIO-Defines', 'XOR'] !!!
```
which I think are expected errors (since the default template is unmodified).

/cc @umarcor (hdl/containers maintainer) to check if this is idiomatic usage.