### PR TITLE
Avoid assigning to constant variables

### DIFF
--- a/checks/tech-files/sky130A_mr.drc
+++ b/checks/tech-files/sky130A_mr.drc
@@ -39,12 +39,6 @@ CU = false  # do not change
 # choose betwen only one of  AL  or  CU  back-end flow here :
 backend_flow = AL
 
-FEOL = false
-BEOL = false
-OFFGRID = false
-SEAL = false
-FLOATING_MET = false
-
 # enable / disable rule groups
 if $feol  == "1"        || $feol == "true"
   FEOL         = true # front-end-of-line checks


### PR DESCRIPTION
These variables are later declared and initialized while parsing command line arguments. This PR avoids these warnings
```
sky130A_mr.drc:50: warning: already initialized constant DRC::DRCEngine::FEOL
sky130A_mr.drc:42: warning: previous definition of FEOL was here
sky130A_mr.drc:56: warning: already initialized constant DRC::DRCEngine::BEOL
sky130A_mr.drc:43: warning: previous definition of BEOL was here
sky130A_mr.drc:62: warning: already initialized constant DRC::DRCEngine::OFFGRID
sky130A_mr.drc:44: warning: previous definition of OFFGRID was here
sky130A_mr.drc:68: warning: already initialized constant DRC::DRCEngine::SEAL
sky130A_mr.drc:45: warning: previous definition of SEAL was here
sky130A_mr.drc:76: warning: already initialized constant DRC::DRCEngine::FLOATING_MET
sky130A_mr.drc:46: warning: previous definition of FLOATING_MET was here
```