### PR TITLE
Bug fix for spi2cdl

### DIFF
--- a/checks/be_checks/tech/sky130A/spi2cdl
+++ b/checks/be_checks/tech/sky130A/spi2cdl
@@ -23,7 +23,7 @@ awk '
         print "C" $0, "$SUB=" bulk;
         next;
 }
-/^X.*pr__res_generic.*=/ {
+/^X.*pr__res_generic_po.*=/ {
         print "R" $0;
         next;
 }

--- a/checks/be_checks/tech/sky130B/spi2cdl
+++ b/checks/be_checks/tech/sky130B/spi2cdl
@@ -23,7 +23,7 @@ awk '
         print "C" $0, "$SUB=" bulk;
         next;
 }
-/^X.*pr__res_generic.*=/ {
+/^X.*pr__res_generic_po.*=/ {
         print "R" $0;
         next;
 }


### PR DESCRIPTION
new generic_po X devices have 2 terminals.
generic_nd and generic_pd X have 3 terminals.
spi2cdl was processing all generic X devices the same. Changed to restore 3 terminal processing for non generic_po X devices.

Without this fix, CVC/OEB will fail for analog(?) designs with `generic_nd` or `generic_pd` devices.